### PR TITLE
Updated contrib.md to allow git branch for documentation branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ git branch <branch-type>/<description>
 | `bugfix`    | what is the bug                                |
 | `testing`   | which component are you testing                |
 | `devops`    | anything related to CI/deployment              |
-| `docs`      | what are you updating in the docs              |
+| `doc`      | what are you updating in the docs              |
 
 > **description** should be not include any whitespaces. Separate it with dashes/underscores.
 


### PR DESCRIPTION
Problem here is that in 
`git branch <branch-type>/<description>`
a documentation branch will have the branch name `docs/desc`, which [cannot be created](https://stackoverflow.com/questions/22630404/git-push-refs-heads-my-subbranch-exists-cannot-create) (since a `docs` branch exists), so just make it `doc/desc`, seems compatible with what we have anyhow