### PR TITLE
influxdb integration (for testing)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 adafruit-ads1x15 = "*"
 adafruit-blinka = "*"
+influxdb = "*"
 
 [dev-packages]
 plotext = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b06a9802c0b1f5a857ae40066f9bcb8514b7ca965c33fa2921f30c30abb60738"
+            "sha256": "286b3f46bb9212ff235dd47f7a75d0a3abd3a95243fbf82d73631ca3897e3282"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -51,6 +51,76 @@
             "markers": "python_full_version >= '3.5.0'",
             "version": "==1.1.9"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+            ],
+            "version": "==2021.10.8"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.9"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.3"
+        },
+        "influxdb": {
+            "hashes": [
+                "sha256:46f85e7b04ee4b3dee894672be6a295c94709003a7ddea8820deec2ac4d8b27a",
+                "sha256:65040a1f53d1a2a4f88a677e89e3a98189a7d30cf2ab61c318aaa89733280747"
+            ],
+            "index": "pypi",
+            "version": "==5.3.1"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:0d8c332f53ffff01953ad25131272506500b14750c1d0ce8614b17d098252fbc",
+                "sha256:1c58cdec1cb5fcea8c2f1771d7b5fec79307d056874f746690bd2bdd609ab147",
+                "sha256:2c3ca57c96c8e69c1a0d2926a6acf2d9a522b41dc4253a8945c4c6cd4981a4e3",
+                "sha256:2f30dd0dc4dfe6231ad253b6f9f7128ac3202ae49edd3f10d311adc358772dba",
+                "sha256:2f97c0f35b3b096a330bb4a1a9247d0bd7e1f3a2eba7ab69795501504b1c2c39",
+                "sha256:36a64a10b16c2ab31dcd5f32d9787ed41fe68ab23dd66957ca2826c7f10d0b85",
+                "sha256:3d875631ecab42f65f9dce6f55ce6d736696ced240f2634633188de2f5f21af9",
+                "sha256:40fb89b4625d12d6027a19f4df18a4de5c64f6f3314325049f219683e07e678a",
+                "sha256:47d733a15ade190540c703de209ffbc42a3367600421b62ac0c09fde594da6ec",
+                "sha256:494471d65b25a8751d19c83f1a482fd411d7ca7a3b9e17d25980a74075ba0e88",
+                "sha256:51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e",
+                "sha256:6eef0cf8db3857b2b556213d97dd82de76e28a6524853a9beb3264983391dc1a",
+                "sha256:6f4c22717c74d44bcd7af353024ce71c6b55346dad5e2cc1ddc17ce8c4507c6b",
+                "sha256:73a80bd6eb6bcb338c1ec0da273f87420829c266379c8c82fa14c23fb586cfa1",
+                "sha256:89908aea5f46ee1474cc37fbc146677f8529ac99201bc2faf4ef8edc023c2bf3",
+                "sha256:8a3a5c4b16e9d0edb823fe54b59b5660cc8d4782d7bf2c214cb4b91a1940a8ef",
+                "sha256:96acc674bb9c9be63fa8b6dabc3248fdc575c4adc005c440ad02f87ca7edd079",
+                "sha256:973ad69fd7e31159eae8f580f3f707b718b61141838321c6fa4d891c4a2cca52",
+                "sha256:9b6f2d714c506e79cbead331de9aae6837c8dd36190d02da74cb409b36162e8a",
+                "sha256:9c0903bd93cbd34653dd63bbfcb99d7539c372795201f39d16fdfde4418de43a",
+                "sha256:9fce00156e79af37bb6db4e7587b30d11e7ac6a02cb5bac387f023808cd7d7f4",
+                "sha256:a598d0685e4ae07a0672b59792d2cc767d09d7a7f39fd9bd37ff84e060b1a996",
+                "sha256:b0a792c091bac433dfe0a70ac17fc2087d4595ab835b47b89defc8bbabcf5c73",
+                "sha256:bb87f23ae7d14b7b3c21009c4b1705ec107cb21ee71975992f6aca571fb4a42a",
+                "sha256:bf1e6bfed4860d72106f4e0a1ab519546982b45689937b40257cfd820650b920",
+                "sha256:c1ba333b4024c17c7591f0f372e2daa3c31db495a9b2af3cf664aef3c14354f7",
+                "sha256:c2140cf7a3ec475ef0938edb6eb363fa704159e0bf71dde15d953bacc1cf9d7d",
+                "sha256:c7e03b06f2982aa98d4ddd082a210c3db200471da523f9ac197f2828e80e7770",
+                "sha256:d02cea2252abc3756b2ac31f781f7a98e89ff9759b2e7450a1c7a0d13302ff50",
+                "sha256:da24375ab4c50e5b7486c115a3198d207954fe10aaa5708f7b65105df09109b2",
+                "sha256:e4c309a68cb5d6bbd0c50d5c71a25ae81f268c2dc675c6f4ea8ab2feec2ac4e2",
+                "sha256:f01b26c2290cbd74316990ba84a14ac3d599af9cebefc543d241a66e785cf17d",
+                "sha256:f201d34dc89342fabb2a10ed7c9a9aaaed9b7af0f16a5923f1ae562b31258dea",
+                "sha256:f74da1e5fcf20ade12c6bf1baa17a2dc3604958922de8dc83cbe3eff22e8b611"
+            ],
+            "version": "==1.0.3"
+        },
         "pyftdi": {
             "hashes": [
                 "sha256:4ef20c246bdb0f278d283337d7a6e69cf9bdb0ead525e7ad867d9e46ad26e613",
@@ -66,6 +136,21 @@
             ],
             "version": "==3.5"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
+                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+            ],
+            "version": "==2021.3"
+        },
         "pyusb": {
             "hashes": [
                 "sha256:2b4c7cb86dbadf044dfb9d3a4ff69fd217013dbe78a792177a3feb172449ea36",
@@ -73,6 +158,30 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.2.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
         }
     },
     "develop": {

--- a/config/influx_setup.sh
+++ b/config/influx_setup.sh
@@ -1,0 +1,3 @@
+export INFLUX_ADDR=localhost
+export INFLUX_PORT=8086
+export INFLUX_DB=laundro-test

--- a/scripts/poll_to_influx.py
+++ b/scripts/poll_to_influx.py
@@ -1,0 +1,68 @@
+import board
+import busio
+from adafruit_ads1x15.ads1015 import ADS1015
+from adafruit_ads1x15.ads1115 import ADS1115
+from adafruit_ads1x15.ads1x15 import Mode
+from adafruit_ads1x15.analog_in import AnalogIn
+
+import os
+import time
+import argparse
+from influxdb import InfluxDBClient
+from typing import Union, List, Tuple
+
+INFLUX_HOST = os.getenv("INFLUX_HOST") or "localhost"
+INFLUX_PORT = int(os.getenv("INFLUX_PORT") or "8086")
+INFLUX_DB = os.getenv("INFLUX_DB") or "laundro-test"
+
+db_client = InfluxDBClient(
+    host=INFLUX_HOST, port=INFLUX_PORT, database=INFLUX_DB)
+db_client.create_database(INFLUX_DB)
+
+
+def log_ldr_value(voltage: float, raw_ads_val: int, ads_addr: int, ads_pin: int):
+    MEASUREMENT_NAME = f"ldr-values-test"
+    field_vals = {"voltage": voltage, "raw_ads_val": raw_ads_val}
+    point = {"measurement": MEASUREMENT_NAME, "fields": field_vals}
+
+    try:
+        return db_client.write_points([point], tags={"ADS_ADDR": ads_addr, "ADS_PIN": ads_pin})
+    except Exception as err:
+        print(f"[log_ldr_value] Error: {err}")
+
+    return
+
+
+def get_ads_addr_pairs(ads1x15: int):
+    i2c = busio.I2C(board.SCL, board.SDA)
+    i2c_dev_addrs = i2c.scan()
+
+    if len(i2c_dev_addrs) == 0:
+        raise Exception("No i2c devices found! Please check wiring/connection")
+
+    def ads_constructor(i2c, addr): return ADS1015(
+        i2c, address=addr, mode=Mode.CONTINUOUS) if ads1x15 == 0 else ADS1115(i2c, address=addr, mode=Mode.CONTINUOUS)
+
+    return list(map(lambda addr: (ads_constructor(i2c, addr), addr), i2c_dev_addrs))
+
+
+def poll_to_influxdb(ads_addr_pairs: List[Tuple[Union[ADS1015, ADS1115], int]], poll_interval: float):
+    print(
+        f"Logging to {INFLUX_HOST}:{INFLUX_PORT}?db={INFLUX_DB} [{time.asctime(time.localtime())}]")
+    while True:
+        for ads, ads_addr in ads_addr_pairs:
+            for pin_no in range(4):
+                chan = AnalogIn(ads, pin_no)
+                log_ldr_value(chan.voltage, chan.value, ads_addr, pin_no)
+        time.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Poll to InfluxDB")
+    parser.add_argument('--ads1x15', type=int,
+                        help="ADS Model (1: ADS1115, 0: ADS1015)", default=0)
+    parser.add_argument('--interval', type=float,
+                        help="Poll Interval", default=0.5)
+    args = parser.parse_args()
+
+    poll_to_influxdb(get_ads_addr_pairs(args.ads1x15), args.interval)


### PR DESCRIPTION
Instead of using `.csv` for storing values, we will be using a time-series database (InfluxDB) for its better storage efficiency and enhanced ability to do data processing and analysis. **However, do note that this is just a test script to test out polling ADS values to a influxdb.**

An added bonus is that we can use grafana to generate sick dashboard for better monitoring:

<img width="1680" alt="dev-dashboard-grafana" src="https://user-images.githubusercontent.com/47914880/146649042-deac1710-7f35-4f9d-969e-4954f40d376d.png">

But the main purpose of this is so that we can set a proper monitoring system to collect data from washers/dryers hopefully in the coming weeks, and subsequently use data recorded in influxdb as testing data for our software to detect when a washer/dryer is in or not in operation.
